### PR TITLE
managed layer controls

### DIFF
--- a/keyboards/drop/alt/keymaps/helldivers/keymap.c
+++ b/keyboards/drop/alt/keymaps/helldivers/keymap.c
@@ -5,14 +5,14 @@
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     //////////////////////////////////////////////////////////////// Default Layers ////////////////////////////////////////////////////////////////
     [_DFL_MACOS] = LAYOUT_65_ansi_blocker(
-        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, H_O_M_E,
+        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, D_I_V_E,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, SWAP_OS,
         KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  TG_NUMP,
         KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,          KC_UP,	  RM_NEXT,
         AU_MCTL, AU_OPTN, AU_CMND,                            KC_SPC,                             MO_CTLL, OS_FUNL, KC_LEFT, KC_DOWN, KC_RGHT
     ),
     [_DFL_WINDOWS] = LAYOUT_65_ansi_blocker(
-        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, H_O_M_E,
+        KC_ESC,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, D_I_V_E,
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, SWAP_OS,
         KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  TG_NUMP,
         KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,          KC_UP,   RM_NEXT,
@@ -25,6 +25,13 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          XXXXXXX, KC_F14,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_LCTL,          _______, KC_F15,
         KC_LCTL, KC_X,    KC_LALT,                            _______,                            CTLRSVP, XXXXXXX, _______, _______, _______
+    ),
+    [_DTL_PROGRAMMING] = LAYOUT_65_ansi_blocker(
+        KC_GRV,  _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, H_O_M_E,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_DEL,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, KC_F2,
+        SC_LSPO, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, SC_RSPC,          _______, KC_F5,
+        _______, _______, _______,                            _______,                            CTLRSVP, FNLRSVP, _______, _______, _______
     ),
     /////////////////////////////////////////////////////////// Exclusive Task Layers //////////////////////////////////////////////////////////////
     [_XTL_MASK] = LAYOUT_65_ansi_blocker(
@@ -41,19 +48,26 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, RM_SPDU,          RM_VALU, RM_NEXT,
         _______, _______, _______,                            XTLRSVP,                            CTLRSVP, FNLRSVP, RM_HUED, RM_VALD, RM_HUEU
     ),
+    [_XTL_NUMPAD] = LAYOUT_65_ansi_blocker(
+        _______, _______, _______, _______, _______, _______, KC_PAST, KC_PSLS, _______, _______, _______, _______, _______, KC_BSPC, XTLRSVP,
+        _______, _______, _______, _______, _______, _______, KC_KP_7, KC_KP_8, KC_KP_9, KC_TAB,  _______, _______, _______, _______, KC_DEL,
+        _______, _______, _______, _______, _______, KC_PMNS, KC_KP_4, KC_KP_5, KC_KP_6, KC_PPLS, _______, _______,          KC_PENT, _______,
+        _______, _______, _______, _______, _______, KC_KP_0, KC_KP_1, KC_KP_2, KC_KP_3, KC_PDOT, _______, KC_PENT,          KC_UP,   _______,
+        _______, _______, _______,                            XTLRSVP,                            CTLRSVP, FNLRSVP, KC_LEFT, KC_DOWN, KC_RGHT
+    ),
     //////////////////////////////////////////////////////////////////// High-touch Layers (ALWAYS LAST) //////////////////////////////////////////////////////////////
     [_XTL_FUNCTION] = LAYOUT_65_ansi_blocker(
         _______, KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_DEL,  XXXXXXX,
-        _______, KC_F13,  KC_F14,  KC_F15,  KC_F16,  KC_F17,  KC_F18,  KC_F19,  KC_F20,  KC_F21,  KC_F22,  KC_F23,  KC_F24,  _______, _______,
+        _______, KC_F13,  KC_F14,  KC_F15,  KC_F16,  KC_F17,  KC_F18,  KC_F19,  KC_F20,  KC_F21,  KC_F22,  KC_F23,  KC_F24,  _______, KC_DEL,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          KC_SPOT, _______,
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, KC_DND,  KC_DICT,          KC_PGUP, _______,
         _______, _______, _______,                            XTLRSVP,                            CTLRSVP, FNLRSVP, KC_HOME, KC_PGDN, KC_END
     ),
     [_XTL_CONTROL] = LAYOUT_65_ansi_blocker(
-        QK_BOOT, TG_NUMP, TG_LEDM, TG_PROG, TG_HELL, _______, _______, _______, _______, _______, _______, EE_CLR,  S_A_V_E, _______, KC_SLEP,
-        PRTYSRC, DF_MCOS, DF_WIND, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, SWAP_OS, KC_WAKE,
-        M_A_S_K, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          TG_LEDM, KC_VOLU,
-        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, PRTYSRC, TG_PROG,          _______, KC_VOLD,
+        QK_BOOT, TG_NUMP, TG_LEDM, TG_PROG, TG_HELL, _______, _______, _______, _______, _______, _______, EE_CLR,  S_A_V_E, _______, SWAP_OS,
+        PRTYSRC, DF_MCOS, DF_WIND, _______, _______, _______, _______, _______, _______, _______, _______, KC_WAKE, KC_SLEP, _______, KC_MUTE,
+        M_A_S_K, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _L_E_D_, KC_VOLU,
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, PRTYSRC, C_O_D_E,          _______, KC_VOLD,
         _______, _______, _______,                            XTLRSVP,                            CTLRSVP, D_F_L_T, KC_MPRV, KC_MPLY, KC_MNXT
     )
     /////////////////////////////////////////////////////////////////////// END //////////////////////////////////////////////////////////////////////////////////////

--- a/keyboards/drop/lib/audreyality/audreyality.c
+++ b/keyboards/drop/lib/audreyality/audreyality.c
@@ -1,2 +1,3 @@
 #include "keys.c"
+#include "layer.c"
 #include "user.c"

--- a/keyboards/drop/lib/audreyality/common.h
+++ b/keyboards/drop/lib/audreyality/common.h
@@ -3,20 +3,6 @@
 #pragma once
 #include "keymap.h"
 
-// layer control data structures
-typedef struct {
-    uint8_t dfl;
-    uint8_t mdl;
-    uint8_t xtl;
-} persistent_layer_t;
-
-typedef struct {
-    bool home;
-    bool skip;
-    bool save;
-    bool load;
-} layer_control_t;
-
 // animation control data structures
 typedef enum {
     LAYER = 0,

--- a/keyboards/drop/lib/audreyality/keymap.h
+++ b/keyboards/drop/lib/audreyality/keymap.h
@@ -19,6 +19,7 @@ enum layer_names {
     _XTL_MASK,
     _XTL_FUNCTION,
     _XTL_LED_MATRIX,
+    _XTL_NUMPAD,
 
     // DTL - default task layer; these layers tweak the default layer,
     //       typically by extending or disabling selected keys.
@@ -41,11 +42,13 @@ enum custom_keycodes {
     MACOS_FOCUS,
 
     SWAP_DFL_HOME,             // persistent layer
-    GOTO_DFL_ACTIVE,           // persistent layer
+    GOTO_DFL,                  // persistent layer
     GOTO_DTL_HELLDIVERS,       // persistent layer
     GOTO_DTL_PROGRAMMING,      // persistent layer
     GOTO_DTL_HOME,             // persistent layer; board-configurable w/ #define
-    GOTO_XTL_MASK,             // runtime layer
+    GOTO_XTL_MASK,
+    GOTO_XTL_NUMPAD,
+    GOTO_XTL_LED_MATRIX,
 
     EEPROM_WRITE_SETTINGS,     // save layers & pretty_source
 
@@ -77,11 +80,14 @@ enum custom_keycodes {
 #endif
 
 // _user logic shorthand
+#define D_F_L_T GOTO_DFL
 #define SWAP_OS SWAP_DFL_HOME
-#define D_F_L_T GOTO_DFL_ACTIVE
-#define D_I_V_E GOTO_DTL_HELLDIVERS
 #define H_O_M_E GOTO_DTL_HOME
+#define D_I_V_E GOTO_DTL_HELLDIVERS
+#define C_O_D_E GOTO_DTL_PROGRAMMING
 #define M_A_S_K GOTO_XTL_MASK
+#define _NUMPD_ GOTO_XTL_NUMPAD
+#define _L_E_D_ GOTO_XTL_LED_MATRIX
 #define S_A_V_E EEPROM_WRITE_SETTINGS
 
 // layer control shorthand

--- a/keyboards/drop/lib/audreyality/layer.c
+++ b/keyboards/drop/lib/audreyality/layer.c
@@ -36,7 +36,6 @@ uint8_t qmk_xtl(void) {
     }
 
     // ** always evaluate separately **
-    // _XTL_CONTROL overrides DTLs and other XTL layers
     if (layer_state_is(_XTL_CONTROL)){
         xtl = _XTL_CONTROL;
     }
@@ -60,8 +59,10 @@ void to_layer(uint8_t layer) {
         case _XTL_CONTROL:
         case _XTL_FUNCTION:
         case _XTL_LED_MATRIX:
-        case _XTL_MASK:
             layer_on(layer);
+            // falls through
+
+        case _XTL_MASK:
             layer_on(_XTL_MASK);
             return;
 

--- a/keyboards/drop/lib/audreyality/layer.c
+++ b/keyboards/drop/lib/audreyality/layer.c
@@ -1,0 +1,86 @@
+#include "common.h"
+
+// check which default layer is active
+uint8_t qmk_dfl(void) {
+    uint8_t dfl = AUD_DEFAULT_LAYER;
+    if(layer_state_is(_DFL_MACOS)) {
+        dfl = _DFL_MACOS;
+    } else if(layer_state_is(_DFL_WINDOWS)) {
+        dfl = _DFL_WINDOWS;
+    }
+    return dfl;
+}
+
+// gather for default task layers
+uint8_t qmk_dtl(void) {
+    uint8_t dtl = 0;
+    if(layer_state_is(_DTL_HELLDIVERS)) {
+        dtl = _DTL_HELLDIVERS;
+    } else if(layer_state_is(_DTL_PROGRAMMING)) {
+        dtl = _DTL_PROGRAMMING;
+    }
+
+    return dtl;
+}
+
+uint8_t qmk_xtl(void) {
+    uint8_t xtl = 0;
+    if(layer_state_is(_XTL_FUNCTION)) {
+        xtl = _XTL_FUNCTION;
+    } else if(layer_state_is(_XTL_LED_MATRIX)) {
+        xtl = _XTL_LED_MATRIX;
+    } else if(layer_state_is(_XTL_MASK)) {
+        // this test must be last because _XTL_MASK is enabled
+        // for most XTL layers
+        xtl = _XTL_MASK;
+    }
+
+    // ** always evaluate separately **
+    // _XTL_CONTROL overrides DTLs and other XTL layers
+    if (layer_state_is(_XTL_CONTROL)){
+        xtl = _XTL_CONTROL;
+    }
+
+    return xtl;
+}
+
+void to_layer(uint8_t layer) {
+    switch (layer) {
+        case _DFL_MACOS:
+        case _DFL_WINDOWS:
+            layer_move(layer);
+            break;
+
+        case _DTL_HELLDIVERS:
+        case _DTL_PROGRAMMING:
+            layer_move(qmk_dfl());
+            layer_on(layer);
+            break;
+
+        case _XTL_CONTROL:
+        case _XTL_FUNCTION:
+        case _XTL_LED_MATRIX:
+        case _XTL_MASK:
+            layer_on(layer);
+            layer_on(_XTL_MASK);
+            return;
+
+        default:
+            layer_off(_XTL_MASK);
+            break;
+    }
+
+    return;
+}
+
+void to_default_layer(void) {
+    to_layer(qmk_dfl());
+}
+
+void to_home_layer(void) {
+#   ifndef AUD_DTL_HOME_LAYER
+#       define AUD_DTL_HOME_LAYER _DFL_MACOS
+#   endif
+
+    to_layer(AUD_DTL_HOME_LAYER);
+}

--- a/keyboards/drop/lib/audreyality/user.c
+++ b/keyboards/drop/lib/audreyality/user.c
@@ -1,5 +1,12 @@
 #include "common.h"
 
+void keyboard_post_init_user(void) {
+    // TODO: when working with led matrix driver,
+    //   initialize the matrix w/ all LEDS on.
+
+    to_home_layer();
+}
+
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case MACOS_SPOTLIGHT:
@@ -43,10 +50,4 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
     }
     return true;
-}
-void keyboard_post_init_user(void) {
-    // TODO: when working with led matrix driver,
-    //   initialize the matrix w/ all LEDS on.
-
-    to_home_layer();
 }

--- a/keyboards/drop/lib/audreyality/user.c
+++ b/keyboards/drop/lib/audreyality/user.c
@@ -8,6 +8,45 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             return send_keycode(record, 0xCF);
         case MACOS_FOCUS:
             return send_keycode(record, 0x9B);
+
+        case SWAP_DFL_HOME:
+            if(qmk_dfl() == _DFL_MACOS) {
+                set_single_persistent_default_layer(_DFL_WINDOWS);
+            } else  {
+                set_single_persistent_default_layer(_DFL_MACOS);
+            }
+            return false;
+
+        case GOTO_DFL:
+            to_default_layer();
+            return false;
+
+        case GOTO_DTL_HOME:
+            to_home_layer();
+            return false;
+        case GOTO_DTL_HELLDIVERS:
+            to_layer(_DTL_HELLDIVERS);
+            return false;
+        case GOTO_DTL_PROGRAMMING:
+            to_layer(_DTL_PROGRAMMING);
+            return false;
+
+        case GOTO_XTL_MASK:
+            to_layer(_XTL_MASK);
+            return false;
+        case GOTO_XTL_LED_MATRIX:
+            to_layer(_XTL_LED_MATRIX);
+            return false;
+        case GOTO_XTL_NUMPAD:
+            to_layer(_XTL_NUMPAD);
+            return false;
+
     }
     return true;
+}
+void keyboard_post_init_user(void) {
+    // TODO: when working with led matrix driver,
+    //   initialize the matrix w/ all LEDS on.
+
+    to_home_layer();
 }


### PR DESCRIPTION
* introduces layer management keycodes
* introduces `AUD_DTL_HOME_LAYER`
  * keyboard boots to this layer
  * defaults to `_DFL_MACOS`

`helldivers` keymap:

* `AUD_DTL_HOME_LAYER` set to `_DTL_HELLDIVERS`
* upper-right button used for helldivers key & OS swap
* Added numpad XTL and programming DTL

